### PR TITLE
Workflow stamp popups do not actually modify workflow data streams in some circumstances

### DIFF
--- a/cwrc_workflow.module
+++ b/cwrc_workflow.module
@@ -396,7 +396,7 @@ function cwrc_workflow_page_alter(&$page) {
           ->fetchField();
 
         if ($lid) {
-          $form['#action'] = $form['#action'] . '?lid=' . $lid;
+          $form['#action'] = $form['#action'] . '/view/history';
         }
       }
     }
@@ -421,8 +421,8 @@ function cwrc_workflow_page_alter(&$page) {
       $both  = array_filter(array_merge(array($first), $last), 'strlen');
       $datastreams = implode(' and ', $both);
       $message = format_plural(count($alerts[$object->id]['ds_string']),
-        'You have edited the <strong>%datastreams</strong> datastream, please add a workflow stamp to this object (you may also do this later from the "History" tab).',
-        'You have edited the <strong>%datastreams</strong> datastreams, please add a workflow stamp to this object (you may also do this later from the "History" tab).',
+        'You have edited the %datastreams datastream.  Please add a workflow stamp to this object (you may also do this later from the "History" tab).',
+        'You have edited the %datastreams datastreams.  Please add a workflow stamp to this object (you may also do this later from the "History" tab).',
         array('%datastreams' => $datastreams));
 
       // Inject form into page bottom region.

--- a/cwrc_workflow.module
+++ b/cwrc_workflow.module
@@ -396,7 +396,7 @@ function cwrc_workflow_page_alter(&$page) {
           ->fetchField();
 
         if ($lid) {
-          $form['#action'] = $form['#action'] . '/view/history';
+          $form['#action'] = $form['#action'] . '/view/history?lid=' . urlencode($lid);
         }
       }
     }


### PR DESCRIPTION
# Problem / motivation

After editing a repository object with the CWRC-Writer or replacing an object's datastream (e.g.: a CWRC document), a workflow stamp popup is shown, but when you fill it out and submit it, a workflow stamp is not actually created. That is to say, the changes show up as a pending workflow item and the information you added in the workflow stamp popup is discarded.

Further investigation suggests that the CWRC-Writer was interfering with the form, preventing it from being submitted properly.

# Proposed resolution

Change the form to submit to another page, e.g.: the item's history page, passing the log ID.

# Remaining tasks

- [ ] Code review
- [ ] Commit

# User interface changes

After submitting a workflow stamp popup, you land on the object's history page.

# API changes

None.

# Data model changes

None.